### PR TITLE
Improve scalability of partial span egress (receiver)

### DIFF
--- a/example/builder-config.yaml
+++ b/example/builder-config.yaml
@@ -11,6 +11,7 @@ exporters:
   - gomod: github.com/G-Research/otel-partial-collector/exporter/otelpartialexporter v0.5.0
 
 processors:
+  - gomod: go.opentelemetry.io/collector/processor/batchprocessor v0.127.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/groupbyattrsprocessor v0.127.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/groupbytraceprocessor v0.127.0
 

--- a/example/config.yaml
+++ b/example/config.yaml
@@ -18,12 +18,14 @@ exporters:
     retry_on_failure:
       initial_interval: 5s
     sending_queue:
+      queue_size: 1000
       batch:
         flush_timeout: 1s
         min_size: 50
         max_size: 100
 
 processors:
+  batch:
   groupbyattrs:
   groupbytrace:
 

--- a/example/config.yaml
+++ b/example/config.yaml
@@ -8,6 +8,7 @@ receivers:
   otelpartialreceiver:
     postgres: "postgres://postgres:test@127.0.0.1:40444/otelpartialcollector?sslmode=disable"
     gc_interval: "5s"
+    batch_max_size: 100
 
 exporters:
   debug:

--- a/internal/postgres/partial_trace.go
+++ b/internal/postgres/partial_trace.go
@@ -103,12 +103,16 @@ WHERE (trace_id, span_id) IN (
 	return nil
 }
 
-func (db *DB) ListExpiredTraces(ctx context.Context, timestamp time.Time) ([]*PartialTrace, error) {
+func (db *DB) ListExpiredTraces(ctx context.Context, timestamp time.Time, limit int64) ([]*PartialTrace, error) {
 	q := `
 SELECT trace_id, span_id, trace FROM partial_traces
 WHERE expires_at < $1
 FOR UPDATE SKIP LOCKED
-	`
+`
+
+	if limit > 0 {
+		q += fmt.Sprintf("LIMIT %d\n", limit)
+	}
 
 	rows, err := db.Query(ctx, q, timestamp)
 	if err != nil {

--- a/receiver/otelpartialreceiver/config.go
+++ b/receiver/otelpartialreceiver/config.go
@@ -1,26 +1,35 @@
 package otelpartialreceiver
 
 import (
-	"fmt"
+	"errors"
 	"time"
 
 	"go.opentelemetry.io/collector/component"
 )
 
 type Config struct {
-	Postgres   string `mapstructure:"postgres"`
-	GCInterval string `mapstructure:"gc_interval"`
+	// Postgres is URL used to connect to the postgres instance.
+	Postgres string `mapstructure:"postgres"`
+
+	// GCInterval is the time to wait between GC runs.
+	GCInterval time.Duration `mapstructure:"gc_interval"`
+
+	// BatchMaxSize is the maximum amount of partial traces to GC in one go.
+	// If set to 0, no limit is applied.
+	BatchMaxSize int64 `mapstructure:"batch_max_size"`
 }
 
 func (c *Config) Validate() error {
-	if _, err := time.ParseDuration(c.GCInterval); err != nil {
-		return fmt.Errorf("failed to parse interval duration: %w", err)
+	if c.GCInterval < 0 {
+		return errors.New("'gc_interval' must be non-negative")
+	}
+	if c.BatchMaxSize < 0 {
 	}
 	return nil
 }
 
 func createDefaultConfig() component.Config {
 	return &Config{
-		GCInterval: "5s",
+		GCInterval: 5 * time.Second,
 	}
 }

--- a/receiver/otelpartialreceiver/config.go
+++ b/receiver/otelpartialreceiver/config.go
@@ -24,6 +24,7 @@ func (c *Config) Validate() error {
 		return errors.New("'gc_interval' must be non-negative")
 	}
 	if c.BatchMaxSize < 0 {
+		return errors.New("'batch_max_size' must be non-negative")
 	}
 	return nil
 }

--- a/receiver/otelpartialreceiver/config_test.go
+++ b/receiver/otelpartialreceiver/config_test.go
@@ -3,6 +3,7 @@ package otelpartialreceiver
 import (
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -17,8 +18,9 @@ func TestLoadConfig(t *testing.T) {
 	require.NoError(t, err)
 
 	want := &Config{
-		Postgres:   "postgres://postgres:test@127.0.0.1:40444/otelpartialcollector?sslmode=disable",
-		GCInterval: "10s",
+		Postgres:     "postgres://postgres:test@127.0.0.1:40444/otelpartialcollector?sslmode=disable",
+		GCInterval:   10 * time.Second,
+		BatchMaxSize: 100,
 	}
 
 	got := createDefaultConfig().(*Config)

--- a/receiver/otelpartialreceiver/otelpartialreceiver.go
+++ b/receiver/otelpartialreceiver/otelpartialreceiver.go
@@ -2,7 +2,6 @@ package otelpartialreceiver
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"math/rand/v2"
 	"time"
@@ -23,10 +22,11 @@ var typeStr = component.MustNewType("otelpartialreceiver")
 var tracesProtoUnmarshaler ptrace.ProtoUnmarshaler
 
 type otelPartialReceiver struct {
-	consumer   consumer.Traces
-	db         *postgres.DB
-	gcInterval time.Duration
-	host       component.Host
+	consumer     consumer.Traces
+	db           *postgres.DB
+	gcInterval   time.Duration
+	batchMaxSize int64
+	host         component.Host
 
 	logger *zap.Logger
 
@@ -41,16 +41,12 @@ func newPartialReceiver(ctx context.Context, params receiver.Settings, baseCfg c
 		return nil, fmt.Errorf("failed to create new db connection: %w", err)
 	}
 
-	d, err := time.ParseDuration(cfg.GCInterval)
-	if err != nil {
-		return nil, fmt.Errorf("failed to parse duration interval: %w", err)
-	}
-
 	r := &otelPartialReceiver{
-		db:         db,
-		logger:     params.Logger,
-		gcInterval: d,
-		consumer:   consumer,
+		db:           db,
+		logger:       params.Logger,
+		gcInterval:   cfg.GCInterval,
+		batchMaxSize: cfg.BatchMaxSize,
+		consumer:     consumer,
 	}
 
 	return r, nil
@@ -81,7 +77,7 @@ func (r *otelPartialReceiver) Shutdown(context.Context) error {
 
 func (r *otelPartialReceiver) loop(ctx context.Context) {
 	for {
-		jitter := time.Millisecond * time.Duration(rand.IntN(1000)-500) // [-500ms,499ms]
+		jitter := time.Duration(rand.Int64N(int64(r.gcInterval/10*2))) - (r.gcInterval / 10) // [-10%,+10%]
 		select {
 		case <-ctx.Done():
 			r.logger.Info("Stopping gc loop after shutdown")
@@ -96,50 +92,70 @@ func (r *otelPartialReceiver) loop(ctx context.Context) {
 }
 
 func (r *otelPartialReceiver) gc(ctx context.Context) error {
-	now := time.Now().UTC()
-	var errs []error
-	if err := r.db.Transact(
-		ctx,
-		pgx.TxOptions{
-			IsoLevel:       pgx.Serializable,
-			AccessMode:     pgx.ReadWrite,
-			DeferrableMode: pgx.NotDeferrable,
-		},
-		func(ctx context.Context, db *postgres.DB) error {
-			traces, err := db.ListExpiredTraces(ctx, now)
-			if err != nil {
-				return fmt.Errorf("failed to get expired traces: %w", err)
-			}
+	// Process expired traces in batch until none are left
+	done := false
+	for !done {
+		if err := r.db.Transact(
+			ctx,
+			pgx.TxOptions{
+				IsoLevel:       pgx.Serializable,
+				AccessMode:     pgx.ReadWrite,
+				DeferrableMode: pgx.NotDeferrable,
+			},
+			func(ctx context.Context, db *postgres.DB) error {
+				now := time.Now().UTC()
 
-			for _, pt := range traces {
-				trace, err := tracesProtoUnmarshaler.UnmarshalTraces(pt.Trace)
+				expiredTraces, err := db.ListExpiredTraces(ctx, now, r.batchMaxSize)
 				if err != nil {
-					errs = append(errs, fmt.Errorf("failed to unmarshal traces: %w", err))
-					continue
+					return fmt.Errorf("failed to get expired traces: %w", err)
 				}
 
-				span := trace.ResourceSpans().At(0).ScopeSpans().At(0).Spans().At(0)
-				span.SetEndTimestamp(pcommon.NewTimestampFromTime(now))
-				attrs := span.Attributes()
-				attrs.PutBool("partial.gc", true)
-
-				if err := r.consumer.ConsumeTraces(ctx, trace); err != nil {
-					errs = append(errs, fmt.Errorf("failed to consume trace %v: %w", trace, err))
-					continue
+				// We can exit once no expired traces are left
+				if len(expiredTraces) == 0 {
+					done = true
+					return nil
 				}
 
-				if err := db.RemoveTrace(ctx, pt.TraceID, pt.SpanID); err != nil {
-					errs = append(errs, fmt.Errorf("failed to rmeove trace: %w", err))
-					continue
+				toSend := ptrace.NewTraces()
+				toDelete := make([]postgres.PartialTraceKey, len(expiredTraces))
+
+				for i, pt := range expiredTraces {
+					// Any expired trace will need to be deleted, even if unmarshalling failed
+					toDelete[i] = postgres.PartialTraceKey{
+						TraceID: pt.TraceID,
+						SpanID:  pt.SpanID,
+					}
+
+					trace, err := tracesProtoUnmarshaler.UnmarshalTraces(pt.Trace)
+					if err != nil {
+						r.logger.Warn("Failed to unmarshal trace", zap.Error(err))
+						continue
+					}
+
+					span := trace.ResourceSpans().At(0).ScopeSpans().At(0).Spans().At(0)
+					span.SetEndTimestamp(pcommon.NewTimestampFromTime(now))
+					attrs := span.Attributes()
+					attrs.PutBool("partial.gc", true)
+
+					trace.ResourceSpans().MoveAndAppendTo(toSend.ResourceSpans())
 				}
-			}
-			return nil
-		},
-	); err != nil {
-		return fmt.Errorf("transaction errors %w: %w", errors.Join(errs...), err)
+
+				if err := r.consumer.ConsumeTraces(ctx, toSend); err != nil {
+					return fmt.Errorf("failed to consume traces %v: %w", toSend, err)
+				}
+
+				if err := db.RemoveTraces(ctx, toDelete); err != nil {
+					return fmt.Errorf("failed to remove traces: %w", err)
+				}
+
+				return nil
+			},
+		); err != nil {
+			return fmt.Errorf("transaction error: %w", err)
+		}
 	}
 
-	return errors.Join(errs...)
+	return nil
 }
 
 func NewFactory() receiver.Factory {

--- a/receiver/otelpartialreceiver/testdata/config.yaml
+++ b/receiver/otelpartialreceiver/testdata/config.yaml
@@ -1,3 +1,4 @@
 otelpartialreceiver:
   postgres: "postgres://postgres:test@127.0.0.1:40444/otelpartialcollector?sslmode=disable"
   gc_interval: "10s"
+  batch_max_size: 100


### PR DESCRIPTION
* Batch the consumer and DB calls to improve performance
* GCInterval/gc_interval is now a proper duration
* Jitter is [-10%,+10%] instead of [-500ms,499ms]
* Traces that cannot be unmarshalled are now deleted
* Any other error stops the GC processing to ensure immediate transaction rollback